### PR TITLE
Fix: AttributeError: module 'iotdb_mcp_server.server' has no attribute 'main'

### DIFF
--- a/src/iotdb_mcp_server/__init__.py
+++ b/src/iotdb_mcp_server/__init__.py
@@ -26,8 +26,7 @@ import asyncio
 
 def main():
     """Main entry point for the package."""
-    _config = Config.from_env_arguments()
-    asyncio.run(server.main(_config))
+    asyncio.run(server.main())
 
 
 # Expose important items at package level

--- a/src/iotdb_mcp_server/server.py
+++ b/src/iotdb_mcp_server/server.py
@@ -273,7 +273,12 @@ elif config.sql_dialect == "table":
             )
         ]
 
-if __name__ == "__main__":
+
+def mian():
     logger.info("iotdb_mcp_server running with stdio transport")
     # Initialize and run the server
     mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    mian()

--- a/src/iotdb_mcp_server/server.py
+++ b/src/iotdb_mcp_server/server.py
@@ -274,11 +274,11 @@ elif config.sql_dialect == "table":
         ]
 
 
-def mian():
+def main():
     logger.info("iotdb_mcp_server running with stdio transport")
     # Initialize and run the server
     mcp.run(transport="stdio")
 
 
 if __name__ == "__main__":
-    mian()
+    main()


### PR DESCRIPTION
Fix: 

```
$ uvx iotdb-mcp-server                          
IoTDB Config: {'host': '127.0.0.1', 'port': 6667, 'user': 'root', 'password': 'root', 'database': 'test', 'sql_dialect': 'table'}
Traceback (most recent call last):
  File "/Users/yanrujing/.cache/uv/archive-v0/hlSJLLUl6MenO7yQ_SJ1P/bin/iotdb-mcp-server", line 12, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/yanrujing/.cache/uv/archive-v0/hlSJLLUl6MenO7yQ_SJ1P/lib/python3.12/site-packages/iotdb_mcp_server/__init__.py", line 30, in main
    asyncio.run(server.main(_config))
                ^^^^^^^^^^^
AttributeError: module 'iotdb_mcp_server.server' has no attribute 'main'

```