### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![smithery badge](https://smithery.ai/badge/@apache/iotdb-mcp-server)](https://smithery.ai/server/@apache/iotdb-mcp-server)
 
+<a href="https://glama.ai/mcp/servers/@apache/iotdb-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@apache/iotdb-mcp-server/badge" alt="IoTDB Server MCP server" />
+</a>
+
 ## Overview
 A Model Context Protocol (MCP) server implementation that provides database interaction and business intelligence capabilities through IoTDB. This server enables running SQL queries.
 


### PR DESCRIPTION
This PR adds a badge for the [IoTDB MCP Server](https://glama.ai/mcp/servers/@apache/iotdb-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@apache/iotdb-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@apache/iotdb-mcp-server/badge" alt="IoTDB Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.