### PR TITLE
Mask password in startup config log output

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -1,7 +1,5 @@
 # IoTDB MCP Server
 
-[![smithery badge](https://smithery.ai/badge/@apache/iotdb-mcp-server)](https://smithery.ai/server/@apache/iotdb-mcp-server)
-
 [English](README.md) | 中文
 
 ## 概述

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # IoTDB MCP Server
 
-[![smithery badge](https://smithery.ai/badge/@apache/iotdb-mcp-server)](https://smithery.ai/server/@apache/iotdb-mcp-server)
-
 English | [中文](README-zh.md)
 
 ## Overview

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license-file="LICENSE"
 requires-python = ">=3.12"
 dependencies = [
     "fastmcp>=2.8.1",
-    "apache-iotdb>=2.0.4",
+    "apache-iotdb>=2.0.10",
     "openpyxl>=3.1.5"
 ]
 

--- a/src/iotdb_mcp_server/config.py
+++ b/src/iotdb_mcp_server/config.py
@@ -17,7 +17,7 @@
 #
 
 import argparse
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import os
 
 
@@ -42,7 +42,7 @@ class Config:
     IoTDB username
     """
 
-    password: str
+    password: str = field(repr=False)
     """
     IoTDB password
     """

--- a/src/iotdb_mcp_server/server.py
+++ b/src/iotdb_mcp_server/server.py
@@ -63,7 +63,9 @@ db_config = {
 
 max_pool_size = 100  # Increased from 100 for better concurrency
 
-logger.info(f"IoTDB Config: {db_config}")
+# Never print credentials: log a copy of the config with the password masked.
+logged_config = {**db_config, "password": "***"}
+logger.info(f"IoTDB Config: {logged_config}")
 
 # Ensure export directory exists
 if not os.path.exists(config.export_path):


### PR DESCRIPTION
The startup log currently prints the full IoTDB config dict, which includes the password field in plain form. This change logs a copy of the config with the password masked as `***`, and also excludes the password from the `Config` repr so it does not show up in any other log or traceback output.

Also included in this PR:
- Remove the outdated smithery badge links from `README.md` and `README-zh.md` (the linked page returns 404)
- Upgrade `apache-iotdb` from `>=2.0.4` to `>=2.0.10`

Verified locally: the startup line now reads

```
IoTDB Config: {'host': '127.0.0.1', 'port': 6667, 'user': 'root', 'password': '***', 'database': 'test', 'sql_dialect': 'table', 'export_path': '/tmp'}
```

Changes:
- `src/iotdb_mcp_server/server.py`: mask the password when logging the config
- `src/iotdb_mcp_server/config.py`: mark the password field with `field(repr=False)`
- `README.md` / `README-zh.md`: remove the smithery badge
- `pyproject.toml`: bump `apache-iotdb` to `>=2.0.10`